### PR TITLE
Update apple-oauth version to get semver fix

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,7 +12,7 @@ Package.onUse(api => {
   api.use('accounts-base', ['client', 'server']);
   api.imply('accounts-base', ['client', 'server']);
   api.use('accounts-oauth', ['client', 'server']);
-  api.use('quave:apple-oauth@1.3.3');
+  api.use('quave:apple-oauth@1.4.2');
   api.imply('quave:apple-oauth');
 
   api.use(


### PR DESCRIPTION
This change bumps the version of quave:apple-oauth to 1.4.2 to fix a semver issue on iOS 14. 

https://github.com/quavedev/apple-oauth/commit/593620037ef8de9a07710688070c0ee35f236f76